### PR TITLE
fix(eslint): set `no-unused-vars` rule to `warn`

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Ayushman Chhabra
+Copyright (c) 2023 Ayushman Chhabra
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,25 +9,25 @@
       "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "uniqid": "5.4.0"
+        "uniqid": "^5.4.0"
       },
       "devDependencies": {
-        "@types/jest": "29.5.5",
-        "@types/node": "18.17.19",
-        "@typescript-eslint/parser": "6.7.2",
-        "esbuild": "0.19.3",
-        "eslint": "8.50.0",
-        "jest": "29.7.0",
-        "jest-environment-jsdom": "29.7.0",
-        "jsdom": "22.1.0",
-        "prettier": "3.0.3",
-        "serve": "14.2.1",
-        "ts-jest": "29.1.1",
-        "tsup": "7.2.0",
-        "typescript": "5.2.2"
+        "@types/jest": "^29.5.5",
+        "@types/node": "^18.17.19",
+        "@typescript-eslint/parser": "^6.7.2",
+        "esbuild": "~0.19.3",
+        "eslint": "^8.50.0",
+        "jest": "^29.7.0",
+        "jest-environment-jsdom": "^29.7.0",
+        "jsdom": "^22.1.0",
+        "prettier": "^3.0.3",
+        "serve": "^14.2.1",
+        "ts-jest": "^29.1.1",
+        "tsup": "^7.2.0",
+        "typescript": "^5.2.2"
       },
       "engines": {
-        "node": ">=v18.16.1",
+        "node": ">= v18.18.0 || >= v20.7.0",
         "npm": ">=9.8.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,8 @@
         "typescript": "^5.2.2"
       },
       "engines": {
-        "node": ">= v18.18.0 || >= v20.7.0",
-        "npm": ">=9.8.0"
+        "node": ">= 18.18.0",
+        "npm": ">= 9.8.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -35,26 +35,26 @@
     "JavaScript"
   ],
   "engines": {
-    "node": ">=v18.16.1",
-    "npm": ">=9.8.0"
+    "node": ">= 18.18.0",
+    "npm": ">= 9.8.0"
   },
   "dependencies": {
-    "uniqid": "5.4.0"
+    "uniqid": "^5.4.0"
   },
   "devDependencies": {
-    "@types/jest": "29.5.5",
-    "@types/node": "18.17.19",
-    "@typescript-eslint/parser": "6.7.2",
-    "esbuild": "0.19.3",
-    "eslint": "8.50.0",
-    "jest": "29.7.0",
-    "jest-environment-jsdom": "29.7.0",
-    "jsdom": "22.1.0",
-    "prettier": "3.0.3",
-    "serve": "14.2.1",
-    "ts-jest": "29.1.1",
-    "tsup": "7.2.0",
-    "typescript": "5.2.2"
+    "@types/jest": "^29.5.5",
+    "@types/node": "^18.17.19",
+    "@typescript-eslint/parser": "^6.7.2",
+    "esbuild": "~0.19.3",
+    "eslint": "^8.50.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "jsdom": "^22.1.0",
+    "prettier": "^3.0.3",
+    "serve": "^14.2.1",
+    "ts-jest": "^29.1.1",
+    "tsup": "^7.2.0",
+    "typescript": "^5.2.2"
   },
   "jest": {
     "preset": "ts-jest",
@@ -82,13 +82,16 @@
   "eslintConfig": {
     "extends": "eslint:recommended",
     "parserOptions": {
-      "ecmaVersion": 2021,
+      "ecmaVersion": 2023,
       "sourceType": "module"
     },
     "env": {
       "es6": true,
       "browser": true
     },
-    "parser": "@typescript-eslint/parser"
+    "parser": "@typescript-eslint/parser",
+    "rules": {
+      "no-unused-vars": "warn"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "format": "prettier --write ./src ./test",
     "lint": "eslint ./src/**/*.ts",
     "build": "tsup src/index.ts --minify --format cjs,esm --dts --clean",
-    "demo": "pnpm build && esbuild ./test/demo/index.tsx --bundle --platform=node --outfile=./test/demo/index.js && serve ./test/demo",
+    "demo": "npm run build && esbuild ./test/demo/index.tsx --bundle --platform=node --outdir=./test/demo --watch --servedir=./test/demo",
     "test": "jest"
   },
   "keywords": [


### PR DESCRIPTION
Fixes: N/A

### Changes

- Lint: Set `no-unused-vars` rule to `warn`
- Test: Use `esbuild` live reload to render demo
- Deps: Use unpin dependencies